### PR TITLE
受講生削除(論理削除)処理機能の実装

### DIFF
--- a/src/main/java/raisetech/studentmanagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/studentmanagement/repository/StudentRepository.java
@@ -14,15 +14,17 @@ import raisetech.studentmanagement.data.StudentCourses;
 public interface StudentRepository {
 
 
-  @Select("SELECT * FROM students")
+  @Select("SELECT * FROM students WHERE is_deleted = false")
   List<Student> search();
 
   @Select("SELECT * FROM students_courses")
   List<StudentCourses> searchStudentCoursesList();
 
   // students()の中身はテーブルのカラム名　valuesの後はstudentのデータ名
-  @Insert("INSERT INTO students(name,ruby,nickname,email,address,age,gender,remark) "
-      + "VALUES(#{name}, #{ruby}, #{nickname}, #{email}, #{address}, #{age}, #{gender}, #{remark})")
+  // 登録時にis_deletedを触れることがないため、Insert文に入れていなかったが、データベース上では常に0のfalse状態である必要がある。
+  // 削除処理するときにNULL値だと判定できないため、1のTrueか0のFalseで判定する。登録時は常にFalse。
+  @Insert("INSERT INTO students(name,ruby,nickname,email,address,age,gender,remark,is_deleted) "
+      + "VALUES(#{name}, #{ruby}, #{nickname}, #{email}, #{address}, #{age}, #{gender}, #{remark}, false)")
   @Options(useGeneratedKeys = true, keyProperty = "id")
   void insertStudent(Student student);
 
@@ -39,7 +41,7 @@ public interface StudentRepository {
   List<StudentCourses> searchStudentCourses(String studentId);
 
   @Update("UPDATE students SET name = #{name}, ruby = #{ruby}, nickname = #{nickname}, email = #{email},"
-      + "address = #{address}, age = #{age}, gender = #{gender}, remark = #{remark} WHERE id = #{id}")
+      + "address = #{address}, age = #{age}, gender = #{gender}, remark = #{remark}, is_deleted = #{isDeleted}  WHERE id = #{id}")
   void updateStudent(Student student);
 
   @Update("UPDATE students_courses SET course_name = #{courseName} WHERE id = #{id}")

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -17,8 +17,8 @@
     <th>地域</th>
     <th>年齢</th>
     <th>性別</th>
-    <th>備考</th>
     <th>コース名</th>
+    <th>備考</th>
   </tr>
   </thead>
   <tbody>
@@ -34,12 +34,12 @@
     <td th:text="${studentDetail.student.address}">東京都千代田区</td>
     <td th:text="${studentDetail.student.age}">20</td>
     <td th:text="${studentDetail.student.gender}">男性</td>
-    <td th:text="${studentDetail.student.remark}">特になし</td>
     <td>
       <ul>
         <li th:each="course : ${studentDetail.studentCourses}" th:text="${course.courseName}">バックエンド開発</li>
       </ul>
     </td>
+    <td th:text="${studentDetail.student.remark}">特になし</td>
   </tr>
   </tbody>
 </table>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -48,11 +48,13 @@
     <label for="remark">備考：</label>
     <input type="text" id="remark" th:field="*{student.remark}"/>
   </div>
-  <div th:each="course, stat : *{studentCourses}">
-    <label for="id" th:for="studentCourse.__${stat.index}__.id">受講生コース名:</label>
-    <input type="text" id="id" th:id="studentCourse.__${stat.index}__.id" th:field="*{studentCourses[__${stat.index}__].id}"/>
+  <div>
+    <label for="isDeleted">キャンセル：</label>
+    <input type="checkbox" id="isDeleted" th:field="*{student.deleted}" />
   </div>
   <div th:each="course, stat : *{studentCourses}">
+    <label for="studentCourseId" th:for="studentCourse.__${stat.index}__.id">受講生コースID:</label>
+    <input type="text" id="studentCourseId" th:id="studentCourse.__${stat.index}__.id" th:field="*{studentCourses[__${stat.index}__].id}"/>
     <label for="courseName" th:for="studentCourse.__${stat.index}__.courseName">受講生コース名:</label>
     <input type="text" id="courseName" th:id="studentCourse.__${stat.index}__.courseName" th:field="*{studentCourses[__${stat.index}__].courseName}"/>
   </div>


### PR DESCRIPTION
# 課題内容
⓵受講生削除（論理削除）処理を更新画面で行う。
➁削除後、削除した受講生を一覧から除いて表示。

# 動作確認
## ⓵削除前の受講生一覧
![スクリーンショット 2024-10-26 070235](https://github.com/user-attachments/assets/36394a0f-5300-438a-b27c-383be3ac8f51)

## ②削除画面
![スクリーンショット 2024-10-26 070244](https://github.com/user-attachments/assets/2e98283a-528c-4015-a08a-d444c0784b07)

## ③削除後の受講生一覧
![スクリーンショット 2024-10-26 070259](https://github.com/user-attachments/assets/a430ec72-3080-4f6c-b7bb-2d4ad6cb1e78)

## MySQLのテーブル表示
![スクリーンショット 2024-10-26 070318](https://github.com/user-attachments/assets/2291da65-73a6-4a40-9019-afcdefb739af)
